### PR TITLE
Get lowest supported browser version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ This logs the percentage each operating system makes up of the total viewership 
 
 This logs the percentage each browser and operating system makes up of the total viewership per service.
 
+### `getLowestSupportedBrowserVersion`
+
+This gives a breakdown of the browser verions that meet our support threshold for each service.
+
 ## I really don't get this repo
 
 1. Rename `browser-stats-example.csv` to `browser-stats.csv`

--- a/browser-stats-example.csv
+++ b/browser-stats-example.csv
@@ -3,6 +3,9 @@ news,iOS 12,Safari 12.x,200,200,200
 news,iOS 12,Chrome for iOS 68.x,500,500,500
 news,iOS 12,Facebook for iPhone 63.x,300,300,300
 news-ws-yoruba,Android 5,Chrome for iOS 68.x,100,100,100
+news-ws-yoruba,Android 5,Chrome for iOS 67.x,100,100,100
+news-ws-yoruba,Android 5,Chrome for iOS 60.x,100,100,100
+news-ws-yoruba,Android 5,Chrome for iOS 52.x,100,100,100
 news-ws-yoruba,Android 5,Facebook for Android 73.x,300,300,300
 news-ws-igbo,BlackBerry OS Touch,BlackBerry Browser 10.x,500,500,500
 news-ws-igbo,Windows XP,Firefox 52.x,700,700,700

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Browser Stats Percentage",
   "scripts": {
     "csvtojson": "node scripts/convertCSVtoJSON.js",
+    "getLowestSupportedBrowserVersion": "node scripts/getSupportedBrowserVersions.js",
     "getBrowserPercentages": "node scripts/getBrowserPercentages.js",
     "getBrowserAndOSPercentages": "node scripts/getBrowserAndOSPercentages.js",
     "getOSPercentages": "node scripts/getOSPercentages.js"

--- a/scripts/getSupportedBrowserVersions.js
+++ b/scripts/getSupportedBrowserVersions.js
@@ -1,0 +1,192 @@
+/* 
+  This node process takes the JSON and creates an object that is keyed per service. 
+  Then for each service each differing browser and version as a string is keyed. 
+  
+  From this object each service is validated to be a correct bbc_site value.
+  Then each browser & version entry is checked to ensure it's above the 0.05% support threshold. 
+  
+    // TODO: The above section should be generic for each node process and should be re-usable/extendable code. 
+
+  Following this it splits the browser name and version into seperate fields.
+  It then creates a new object with the browser keyed and the versions as entries. 
+  Finally it logs out the lowest supported version for each browser. 
+
+  TL;DR - it outputs the browsers we should aim support as they are within our threshold of support.
+*/
+
+const fs = require("fs");
+const data = fs.readFileSync("./browser-stats.json");
+const { isValidBBCSiteValue } = require("../utility");
+
+let dataKeyedPerService = {};
+let serviceTotalBrowsers = {};
+
+const getPercentagePerBrowser = (views, service) =>
+  ((views / serviceTotalBrowsers[service]) * 100).toFixed(3);
+
+const countAllViews = (service, browserViews, countArray) => {
+  // if the array doesn't have the service name as a key
+  if (!countArray.hasOwnProperty(service)) {
+    // add a new array key with the value
+    countArray[service] = parseInt(browserViews);
+  } else {
+    // if the service is already a key in the array just add the value
+    countArray[service] += parseInt(browserViews);
+  }
+};
+
+/*
+  This method allows an empty object to be populated with values that have matching keys.
+  It does this by checking if the key exists and either creating it or cumulatively adding to the key's value
+*/
+const addToDynamicallyKeyedObject = (firstKey, secondKey, value, object) => {
+  // if the array doesn't have the service name as a key
+  if (!object.hasOwnProperty(firstKey)) {
+    object[firstKey] = {};
+  }
+
+  object[firstKey][secondKey] = value;
+};
+
+const generatorBrowserPercentagesObject = data => {
+  data.forEach(item => {
+    if (isValidBBCSiteValue(item["bbc_site"])) {
+      countAllViews(item["bbc_site"], item["Browsers"], serviceTotalBrowsers);
+
+      addToDynamicallyKeyedObject(
+        item["bbc_site"],
+        item["Web browser"],
+        item["Browsers"],
+        dataKeyedPerService
+      );
+    }
+  });
+};
+
+const splitVersionFromBrowser = browserNameWithVersion => {
+  // get the version numbers from the current browserDataWithVersion entry
+  const versionRegex = / ([0-9]+)(\.x)/;
+
+  // return the full value for things like `Nokia 6280` and `MAUI WAP Browser`
+  let version = browserNameWithVersion;
+  let browserName = browserNameWithVersion;
+
+  const matches = browserNameWithVersion.match(versionRegex);
+
+  if (matches) {
+    browserName = browserNameWithVersion.replace(matches[0], "");
+    version = parseInt(matches[1]);
+  }
+
+  return { version, browserName };
+};
+
+const checkBrowserStatsMeetSupportCriteria = (
+  browserDataWithVersion,
+  service
+) => {
+  const percentageBrowsers = getPercentagePerBrowser(
+    browserDataWithVersion,
+    service
+  );
+
+  // if the percentage value is above our support threshold
+  if (percentageBrowsers > 0.05) {
+    return browserDataWithVersion;
+  }
+};
+
+const updateBrowserKeysAndAddLowestVersionValues = (
+  service,
+  browserNameWithVersion,
+  browserName,
+  version
+) => {
+  // if the browser key doesn't yet exist create it
+  if (!dataKeyedPerService[service].hasOwnProperty(browserName)) {
+    dataKeyedPerService[service][browserName] = version;
+  }
+  // set the value to the lowest version
+  if (version < dataKeyedPerService[service][browserName]) {
+    dataKeyedPerService[service][browserName] = version;
+  }
+
+  delete dataKeyedPerService[service][browserNameWithVersion];
+
+  if (browserNameWithVersion === "Unknown") {
+    delete dataKeyedPerService[service][browserNameWithVersion];
+  }
+};
+
+const handleDataPerService = service => {
+  const browserKeys = Object.keys(dataKeyedPerService[service]);
+
+  const browsers = browserKeys.map(browserNameWithVersion => {
+    const browserDataWithVersion =
+      dataKeyedPerService[service][browserNameWithVersion];
+    if (checkBrowserStatsMeetSupportCriteria(browserDataWithVersion, service)) {
+      const { browserName, version } = splitVersionFromBrowser(
+        browserNameWithVersion
+      );
+
+      updateBrowserKeysAndAddLowestVersionValues(
+        service,
+        browserNameWithVersion,
+        browserName,
+        version
+      );
+    }
+  });
+
+  browsers.forEach(browser => {
+    const lowestVersion = dataKeyedPerService[service][browser];
+    console.log(
+      `| ${service}                     | ${browser}           | ${lowestVersion}    |`
+    );
+  });
+};
+
+// const consoleLogSupportedBrowserVersions = () => {
+//   const services = Object.keys(dataKeyedPerService);
+
+//   console.log(
+//     "| Service                     | Browser           | Lowest version    |"
+//   );
+//   console.log(
+//     "| --------------------------- | ----------------- | ---------- |"
+//   );
+
+//   services.forEach(service => {
+//     const browsers = Object.keys(dataKeyedPerService[service]);
+
+//     browsers.forEach(browser => {
+//       const lowestVersion = dataKeyedPerService[service][browser];
+//       console.log(
+//         `| ${service}                     | ${browser}           | ${lowestVersion}    |`
+//       );
+//     });
+//   });
+// };
+
+const getManipulatedData = () => {
+  const services = Object.keys(dataKeyedPerService);
+
+  services.forEach(service => {
+    handleDataPerService(service);
+  });
+};
+
+const getLowestBrowserVersionPercentages = data => {
+  generatorBrowserPercentagesObject(data);
+
+  console.log(
+    "| Service                     | Browser           | Lowest version    |"
+  );
+  console.log(
+    "| --------------------------- | ----------------- | ---------- |"
+  );
+
+  getManipulatedData();
+};
+
+getLowestBrowserVersionPercentages(JSON.parse(data));

--- a/scripts/getSupportedBrowserVersions.js
+++ b/scripts/getSupportedBrowserVersions.js
@@ -1,183 +1,45 @@
 /* 
   This node process takes the JSON and creates an object that is keyed per service. 
-  Then for each service each differing browser and version as a string is keyed. 
+  Then for each service it contains each differing browser and version as a keyed string. 
   
-  From this object each service is validated to be a correct bbc_site value.
+  From this object each service is validated to be a correct 'bbc_site' value.
   Then each browser & version entry is checked to ensure it's above the 0.05% support threshold. 
-  
-    // TODO: The above section should be generic for each node process and should be re-usable/extendable code. 
 
-  Following this it splits the browser name and version into seperate fields.
-  It then creates a new object with the browser keyed and the versions as entries. 
-  Finally it logs out the lowest supported version for each browser. 
-
-  TL;DR - it outputs the browsers we should aim support as they are within our threshold of support.
+  Following this it creates an array of versions for each browser.
+  Finally it logs out the lowest supported version for each browser per service. 
 */
 
 const fs = require("fs");
-const data = fs.readFileSync("./browser-stats.json");
-const { isValidBBCSiteValue } = require("../utility");
+const dataAsJSON = fs.readFileSync("./browser-stats.json", "utf8");
+const { removeInvalidValues } = require("./helpers/removeInvalidValues");
+const {
+  getServiceTotalBrowsers
+} = require("./helpers/getServiceTotalBrowsers");
+const { getDataWithinThreshold } = require("./helpers/getDataWithinThreshold");
+const {
+  seperateBrowserNameAndVersion
+} = require("./helpers/seperateBrowserNameAndVersion");
 
-let dataKeyedPerService = {};
-let serviceTotalBrowsers = {};
+const data = JSON.parse(dataAsJSON);
 
-const getPercentagePerBrowser = (views, service) =>
-  ((views / serviceTotalBrowsers[service]) * 100).toFixed(3);
+// pass over data removing all invalid enteries
+const validData = removeInvalidValues(data);
 
-const countAllViews = (service, browserViews, countArray) => {
-  // if the array doesn't have the service name as a key
-  if (!countArray.hasOwnProperty(service)) {
-    // add a new array key with the value
-    countArray[service] = parseInt(browserViews);
-  } else {
-    // if the service is already a key in the array just add the value
-    countArray[service] += parseInt(browserViews);
-  }
-};
+// get the total per each service
+const totalBrowsersPerService = getServiceTotalBrowsers(validData);
 
-/*
-  This method allows an empty object to be populated with values that have matching keys.
-  It does this by checking if the key exists and either creating it or cumulatively adding to the key's value
-*/
-const addToDynamicallyKeyedObject = (firstKey, secondKey, value, object) => {
-  // if the array doesn't have the service name as a key
-  if (!object.hasOwnProperty(firstKey)) {
-    object[firstKey] = {};
-  }
+// remove enteries not in threshold
+const dataWithSupportThreshold = getDataWithinThreshold(
+  validData,
+  totalBrowsersPerService
+);
 
-  object[firstKey][secondKey] = value;
-};
+const getDataWithBrowsersAndVersionArray = seperateBrowserNameAndVersion(
+  dataWithSupportThreshold
+);
 
-const generatorBrowserPercentagesObject = data => {
-  data.forEach(item => {
-    if (isValidBBCSiteValue(item["bbc_site"])) {
-      countAllViews(item["bbc_site"], item["Browsers"], serviceTotalBrowsers);
-
-      addToDynamicallyKeyedObject(
-        item["bbc_site"],
-        item["Web browser"],
-        item["Browsers"],
-        dataKeyedPerService
-      );
-    }
-  });
-};
-
-const splitVersionFromBrowser = browserNameWithVersion => {
-  // get the version numbers from the current browserDataWithVersion entry
-  const versionRegex = / ([0-9]+)(\.x)/;
-
-  // return the full value for things like `Nokia 6280` and `MAUI WAP Browser`
-  let version = browserNameWithVersion;
-  let browserName = browserNameWithVersion;
-
-  const matches = browserNameWithVersion.match(versionRegex);
-
-  if (matches) {
-    browserName = browserNameWithVersion.replace(matches[0], "");
-    version = parseInt(matches[1]);
-  }
-
-  return { version, browserName };
-};
-
-const checkBrowserStatsMeetSupportCriteria = (
-  browserDataWithVersion,
-  service
-) => {
-  const percentageBrowsers = getPercentagePerBrowser(
-    browserDataWithVersion,
-    service
-  );
-
-  // if the percentage value is above our support threshold
-  if (percentageBrowsers > 0.05) {
-    return browserDataWithVersion;
-  }
-};
-
-const updateBrowserKeysAndAddLowestVersionValues = (
-  service,
-  browserNameWithVersion,
-  browserName,
-  version
-) => {
-  // if the browser key doesn't yet exist create it
-  if (!dataKeyedPerService[service].hasOwnProperty(browserName)) {
-    dataKeyedPerService[service][browserName] = version;
-  }
-  // set the value to the lowest version
-  if (version < dataKeyedPerService[service][browserName]) {
-    dataKeyedPerService[service][browserName] = version;
-  }
-
-  delete dataKeyedPerService[service][browserNameWithVersion];
-
-  if (browserNameWithVersion === "Unknown") {
-    delete dataKeyedPerService[service][browserNameWithVersion];
-  }
-};
-
-const handleDataPerService = service => {
-  const browserKeys = Object.keys(dataKeyedPerService[service]);
-
-  const browsers = browserKeys.map(browserNameWithVersion => {
-    const browserDataWithVersion =
-      dataKeyedPerService[service][browserNameWithVersion];
-    if (checkBrowserStatsMeetSupportCriteria(browserDataWithVersion, service)) {
-      const { browserName, version } = splitVersionFromBrowser(
-        browserNameWithVersion
-      );
-
-      updateBrowserKeysAndAddLowestVersionValues(
-        service,
-        browserNameWithVersion,
-        browserName,
-        version
-      );
-    }
-  });
-
-  browsers.forEach(browser => {
-    const lowestVersion = dataKeyedPerService[service][browser];
-    console.log(
-      `| ${service}                     | ${browser}           | ${lowestVersion}    |`
-    );
-  });
-};
-
-// const consoleLogSupportedBrowserVersions = () => {
-//   const services = Object.keys(dataKeyedPerService);
-
-//   console.log(
-//     "| Service                     | Browser           | Lowest version    |"
-//   );
-//   console.log(
-//     "| --------------------------- | ----------------- | ---------- |"
-//   );
-
-//   services.forEach(service => {
-//     const browsers = Object.keys(dataKeyedPerService[service]);
-
-//     browsers.forEach(browser => {
-//       const lowestVersion = dataKeyedPerService[service][browser];
-//       console.log(
-//         `| ${service}                     | ${browser}           | ${lowestVersion}    |`
-//       );
-//     });
-//   });
-// };
-
-const getManipulatedData = () => {
-  const services = Object.keys(dataKeyedPerService);
-
-  services.forEach(service => {
-    handleDataPerService(service);
-  });
-};
-
-const getLowestBrowserVersionPercentages = data => {
-  generatorBrowserPercentagesObject(data);
+const getBrowserWithLowestSupportVersions = () => {
+  const data = getDataWithBrowsersAndVersionArray;
 
   console.log(
     "| Service                     | Browser           | Lowest version    |"
@@ -186,7 +48,20 @@ const getLowestBrowserVersionPercentages = data => {
     "| --------------------------- | ----------------- | ---------- |"
   );
 
-  getManipulatedData();
+  const services = Object.keys(data);
+
+  services.forEach(service => {
+    const browsers = Object.keys(data[service]);
+
+    browsers.forEach(browser => {
+      const browserVersions = data[service][browser];
+      const lowestVersion = Math.min.apply(null, browserVersions);
+
+      console.log(
+        `| ${service}        | ${browser}           | ${lowestVersion}    |`
+      );
+    });
+  });
 };
 
-getLowestBrowserVersionPercentages(JSON.parse(data));
+getBrowserWithLowestSupportVersions();

--- a/scripts/helpers/getDataWithinThreshold.js
+++ b/scripts/helpers/getDataWithinThreshold.js
@@ -1,0 +1,40 @@
+let dataWithinThreshold = {};
+
+const isWithinThreshold = (views, totalBrowsersForService) => {
+  const percentage = ((views / totalBrowsersForService) * 100).toFixed(3);
+
+  if (percentage > 0.05) {
+    return true;
+  }
+
+  return false;
+};
+
+const addToDataObject = (service, browserName, browserViews) => {
+  // if the array doesn't have the service name as a key
+  if (!dataWithinThreshold.hasOwnProperty(service)) {
+    dataWithinThreshold[service] = {};
+  }
+
+  dataWithinThreshold[service][browserName] = browserViews;
+};
+
+module.exports.getDataWithinThreshold = (data, totalBrowsersPerService) => {
+  data.forEach(entry => {
+    const browserName = entry["Web browser"];
+    const browserViews = entry["Browsers"];
+    const service = entry["bbc_site"];
+    const serviceTotalViews = totalBrowsersPerService[service];
+
+    if (isWithinThreshold(browserViews, serviceTotalViews)) {
+      addToDataObject(service, browserName, browserViews);
+    } else {
+      // debug mode flag needed
+      // console.log(
+      // `The ${browserName} has been removed as it did not meet the 0.05% threshold for ${service}.`
+      // );
+    }
+  });
+
+  return dataWithinThreshold;
+};

--- a/scripts/helpers/getServiceTotalBrowsers.js
+++ b/scripts/helpers/getServiceTotalBrowsers.js
@@ -1,0 +1,20 @@
+let serviceTotalBrowsers = [];
+
+const countAllViews = (service, browserViews) => {
+  // if the array doesn't have the service name as a key
+  if (!serviceTotalBrowsers.hasOwnProperty(service)) {
+    // add a new array key with the value
+    serviceTotalBrowsers[service] = parseInt(browserViews);
+  } else {
+    // if the service is already a key in the array just add the value
+    serviceTotalBrowsers[service] += parseInt(browserViews);
+  }
+};
+
+module.exports.getServiceTotalBrowsers = data => {
+  data.forEach(entry => {
+    countAllViews(entry["bbc_site"], entry["Browsers"]);
+  });
+
+  return serviceTotalBrowsers;
+};

--- a/scripts/helpers/removeInvalidValues.js
+++ b/scripts/helpers/removeInvalidValues.js
@@ -1,0 +1,66 @@
+const validServices = [
+  "news",
+  "news-ws-afaanoromoo",
+  "news-ws-afrique",
+  "news-ws-amharic",
+  "news-ws-arabic",
+  "news-ws-azeri",
+  "news-ws-bengali",
+  "news-ws-burmese",
+  "news-ws-cymrufyw",
+  "news-ws-gahuza",
+  "news-ws-gujarati",
+  "news-ws-hausa",
+  "news-ws-hindi",
+  "news-ws-igbo",
+  "news-ws-indonesia",
+  "news-ws-japanese",
+  "news-ws-korean",
+  "news-ws-kyrgyz",
+  "news-ws-marathi",
+  "news-ws-mundo",
+  "news-ws-naidheachdan",
+  "news-ws-nepali",
+  "news-ws-newyddion",
+  "news-ws-pashto",
+  "news-ws-persian",
+  "news-ws-pidgin",
+  "news-ws-portuguese",
+  "news-ws-punjabi",
+  "news-ws-russian",
+  "news-ws-schoolreport",
+  "news-ws-serbian",
+  "news-ws-sinhala",
+  "news-ws-somali",
+  "news-ws-swahili",
+  "news-ws-tajik",
+  "news-ws-tamil",
+  "news-ws-telugu",
+  "news-ws-thai",
+  "news-ws-tigrinya",
+  "news-ws-turkce",
+  "news-ws-ukchina",
+  "news-ws-ukrainian",
+  "news-ws-urdu",
+  "news-ws-uzbek",
+  "news-ws-vietnamese",
+  "news-ws-yoruba",
+  "news-ws-zhongwen"
+];
+
+const isValidBBCSiteValue = service => {
+  if (validServices.includes(service)) {
+    return true;
+  }
+
+  // console.log(`Removing entry with the bbc_site value: ${service}`); // debug mode flag needed
+  return false;
+};
+
+module.exports.removeInvalidValues = data => {
+  let validData = data.map(entry => {
+    return isValidBBCSiteValue(entry["bbc_site"]) ? entry : undefined;
+  });
+
+  return validData.filter(undefined => undefined);
+};

--- a/scripts/helpers/seperateBrowserNameAndVersion.js
+++ b/scripts/helpers/seperateBrowserNameAndVersion.js
@@ -1,0 +1,73 @@
+const modifiedData = {};
+let browsersWithVersionSeperated = {};
+
+const splitVersionFromBrowser = browserNameWithVersion => {
+  // get the version numbers from the current browserDataWithVersion entry. Most enteries are similar to "Chrome 45.x"
+  const versionRegexWithTrailingDotX = / ([0-9]+)(\.x)/;
+  // This is needed for enteries that do not have a trailing '.x' such as 'Nokia 2860'
+  const versionRegex = / ([0-9]+)/;
+
+  // default the version to empty string for things like "Safari" or "Chrome"
+  let version = "";
+  // return the full values for things that don't have a number version like "Safari" or "MAUI WAP Browser"
+  let browserName = browserNameWithVersion;
+
+  // DotX === '.x'
+  const matchesWithTrailingDotX = browserNameWithVersion.match(
+    versionRegexWithTrailingDotX
+  );
+  const matches = browserNameWithVersion.match(versionRegex);
+
+  if (matchesWithTrailingDotX) {
+    browserName = browserNameWithVersion.replace(
+      matchesWithTrailingDotX[0],
+      ""
+    );
+    version = parseInt(matchesWithTrailingDotX[1]);
+  } else if (matches) {
+    browserName = browserNameWithVersion.replace(matches[0], "");
+    version = parseInt(matches[1]);
+  } else {
+    // debug mode flag needed
+    // console.log(
+    // `Could not extract version from the Browser name: ${browserNameWithVersion}`
+    // );
+  }
+
+  return { version, browserName };
+};
+
+const createBrowserObjectWithAnArrayOfVersions = (browserName, version) => {
+  // remove unknown browser count
+  if (browserName !== "Unknown" && browserName !== undefined) {
+    // if the browser has already been keyed add the next version
+    if (browsersWithVersionSeperated.hasOwnProperty(browserName)) {
+      browsersWithVersionSeperated[browserName].push(version);
+    } else {
+      // the browser is not yet keyed in the object, create an array populated with the first version
+      browsersWithVersionSeperated[browserName] = [version];
+    }
+  }
+};
+
+module.exports.seperateBrowserNameAndVersion = data => {
+  const services = Object.keys(data);
+
+  services.forEach(service => {
+    const browserNameWithConcatVersion = Object.keys(data[service]);
+
+    browserNameWithConcatVersion.forEach(browserNameAndVersion => {
+      const { browserName, version } = splitVersionFromBrowser(
+        browserNameAndVersion
+      );
+
+      createBrowserObjectWithAnArrayOfVersions(browserName, version);
+    });
+
+    modifiedData[service] = browsersWithVersionSeperated;
+
+    browsersWithVersionSeperated = {};
+  });
+
+  return modifiedData;
+};

--- a/utility.js
+++ b/utility.js
@@ -1,15 +1,3 @@
-module.exports.doesNotSupportSrcSet = browser =>
-  isIE11orLower(browser) ||
-  isEdge12to15(browser) ||
-  isFirefox1to37(browser) ||
-  isChrome1to33(browser) ||
-  isSafariLessThan7(browser) || // covers both desktop and ios
-  isOperaLessThan20(browser) ||
-  isOperaMini(browser) ||
-  isAndroidLessThan4(browser) ||
-  isBlackberryBrowser(browser) ||
-  isOperaMobile(browser);
-
 const isIE11orLower = browser => {
   var regex = /IE ([1-9]|10|11)\.x/g;
   return regexMatch(regex, browser);
@@ -66,3 +54,73 @@ const regexMatch = (regex, browser) => {
   }
   return false;
 };
+
+const validServices = [
+  "news",
+  "news-ws-afaanoromoo",
+  "news-ws-afrique",
+  "news-ws-amharic",
+  "news-ws-arabic",
+  "news-ws-azeri",
+  "news-ws-bengali",
+  "news-ws-burmese",
+  "news-ws-cymrufyw",
+  "news-ws-gahuza",
+  "news-ws-gujarati",
+  "news-ws-hausa",
+  "news-ws-hindi",
+  "news-ws-igbo",
+  "news-ws-indonesia",
+  "news-ws-japanese",
+  "news-ws-korean",
+  "news-ws-kyrgyz",
+  "news-ws-marathi",
+  "news-ws-mundo",
+  "news-ws-naidheachdan",
+  "news-ws-nepali",
+  "news-ws-newyddion",
+  "news-ws-pashto",
+  "news-ws-persian",
+  "news-ws-pidgin",
+  "news-ws-portuguese",
+  "news-ws-punjabi",
+  "news-ws-russian",
+  "news-ws-schoolreport",
+  "news-ws-serbian",
+  "news-ws-sinhala",
+  "news-ws-somali",
+  "news-ws-swahili",
+  "news-ws-tajik",
+  "news-ws-tamil",
+  "news-ws-telugu",
+  "news-ws-thai",
+  "news-ws-tigrinya",
+  "news-ws-turkce",
+  "news-ws-ukchina",
+  "news-ws-ukrainian",
+  "news-ws-urdu",
+  "news-ws-uzbek",
+  "news-ws-vietnamese",
+  "news-ws-yoruba",
+  "news-ws-zhongwen"
+];
+
+module.exports.isValidBBCSiteValue = service => {
+  if (validServices.includes(service)) {
+    return true;
+  }
+
+  return false;
+};
+
+module.exports.doesNotSupportSrcSet = browser =>
+  isIE11orLower(browser) ||
+  isEdge12to15(browser) ||
+  isFirefox1to37(browser) ||
+  isChrome1to33(browser) ||
+  isSafariLessThan7(browser) || // covers both desktop and ios
+  isOperaLessThan20(browser) ||
+  isOperaMini(browser) ||
+  isAndroidLessThan4(browser) ||
+  isBlackberryBrowser(browser) ||
+  isOperaMobile(browser);


### PR DESCRIPTION
Creates a new command to print out the lowest supported browser version per service. Output in comments. 

- Also creates helper functions to simplify handling the data for future use cases and code clarity 
- Updates example data to work with new command
- Does add some extraneous code but this will be cleared up in a future refactor to use the newly created helpers